### PR TITLE
xjs spread attribute

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -2260,6 +2260,20 @@
             return result;
         },
 
+        XJSSpreadAttribute: function (expr, precedence, flags) {
+            var result = ['{...'];
+
+            var fragment = this.generateExpression(expr.argument, Precedence.Sequence, {
+                allowIn: true,
+                allowCall: true
+            });
+
+            result.push(fragment);
+            result.push('}');
+
+            return result;
+        },
+
         XJSClosingElement: function (expr, precedence, flags) {
             return [
                 '</',
@@ -2382,7 +2396,6 @@
                 fragment = that.generateExpression(expr.attributes[i], Precedence.Sequence, E_TTF);
                 xjsFragments.push({
                     expr: expr.attributes[i],
-                    name: expr.attributes[i].name.name,
                     fragment: fragment,
                     multiline: hasLineTerminator(toSourceNodeWhenNeeded(fragment).toString())
                 });
@@ -2391,19 +2404,6 @@
                     xjsFragments[xjsFragments.length - 1].multiline = true;
                 }
             }
-
-            xjsFragments.sort(function(a, b) {
-                if (!a.multiline && !b.multiline) {
-                    return a.name > b.name ? 1 : -1;
-                }
-                if (!a.multiline) {
-                    return -1;
-                }
-                if (!b.multiline) {
-                    return 1;
-                }
-                return a.name > b.name ? 1 : -1;
-            });
 
             withIndent(function(indent) {
                 for (var i = 0, len = xjsFragments.length; i < len; ++i) {

--- a/escodegen.js
+++ b/escodegen.js
@@ -1128,7 +1128,7 @@
 
             // export default HoistableDeclaration[Default]
             // export default AssignmentExpression[In] ;
-            if (stmt['default']) {
+            if (stmt.default) {
                 result = join(result, 'default');
                 if (isStatement(stmt.declaration)) {
                     result = join(result, this.generateStatement(stmt.declaration, bodyFlags));
@@ -1699,8 +1699,8 @@
             // F_ALLOW_UNPARATH_NEW becomes false.
             result = [this.generateExpression(expr.callee, Precedence.Call, E_TTF)];
             result.push('(');
-            for (i = 0, iz = expr['arguments'].length; i < iz; ++i) {
-                result.push(this.generateExpression(expr['arguments'][i], Precedence.Assignment, E_TTT | F_XJS_NOPAREN));
+            for (i = 0, iz = expr.arguments.length; i < iz; ++i) {
+                result.push(this.generateExpression(expr.arguments[i], Precedence.Assignment, E_TTT | F_XJS_NOPAREN));
                 if (i + 1 < iz) {
                     result.push(',' + space);
                 }
@@ -1715,7 +1715,7 @@
 
         NewExpression: function (expr, precedence, flags) {
             var result, length, i, iz, itemFlags;
-            length = expr['arguments'].length;
+            length = expr.arguments.length;
 
             // F_ALLOW_CALL becomes false.
             // F_ALLOW_UNPARATH_NEW may become false.
@@ -1729,7 +1729,7 @@
             if (!(flags & F_ALLOW_UNPARATH_NEW) || parentheses || length > 0) {
                 result.push('(');
                 for (i = 0, iz = length; i < iz; ++i) {
-                    result.push(this.generateExpression(expr['arguments'][i], Precedence.Assignment, E_TTT));
+                    result.push(this.generateExpression(expr.arguments[i], Precedence.Assignment, E_TTT));
                     if (i + 1 < iz) {
                         result.push(',' + space);
                     }
@@ -1913,7 +1913,7 @@
 
         MethodDefinition: function (expr, precedence, flags) {
             var result, fragment;
-            if (expr['static']) {
+            if (expr.static) {
                 result = ['static' + space];
             } else {
                 result = [];
@@ -2439,7 +2439,7 @@
 
 
         if (extra.comment) {
-            result = addComments(expr,result);
+            result = addComments(expr, result);
         }
         return toSourceNodeWhenNeeded(result, expr);
     };

--- a/test/compare-jsx/attributes.expected.jsx
+++ b/test/compare-jsx/attributes.expected.jsx
@@ -1,13 +1,19 @@
 <div>
     <div a='a'></div>
-    <div a='a' b c={c() * 2}>text</div>
-    <div a='a' b d
-        c={c() * 2}>
+    <div a='a' c={c() * 2} b>text</div>
+    <div a='a'
+        c={c() * 2} {...c}
+        b>
         text
     </div>
-    <div a='a' b c="'c'"
-        d='d' e='e' f
-        g>
+    <div a='a'
+        c={c() * 2} {...c}
+        b {...(c()) * 2} d>
+        text
+    </div>
+    <div a='a' b e='e'
+        f d='d' g
+        c="'c'">
         text
     </div>
     <div a='a' b
@@ -17,12 +23,13 @@
         })}>
         text
     </div>
-    <div a='a' b
+    <div
         c={c() * 2}
+        e={{ e: 'e' }} {...(c()) * 2}
+        a='a'
         d={d(function () {
             return d;
-        })}
-        e={{ e: 'e' }}
+        })} b
         f={{
             e: 'e',
             f: 'f'

--- a/test/compare-jsx/attributes.jsx
+++ b/test/compare-jsx/attributes.jsx
@@ -1,8 +1,9 @@
 <div>
     <div a='a'></div>
     <div a='a' c={c()*2} b>text</div>
-    <div a='a' c={c()*2} b d>text</div>
+    <div a='a' c={c()*2} {...c} b>text</div>
+    <div a='a' c={c()*2} {...c} b {...c()*2} d>text</div>
     <div a='a' b e='e' f d='d' g c="'c'">text</div>
     <div a='a' b c={c()*2} d={d(function(){return d;})}>text</div>
-    <div c={c()*2} e={{e:'e'}} a='a' d={d(function(){return d;})} b f={{e:'e',f:'f'}} g={g({g:'g'})} h={{h:function(){return h;}}}>text</div>
+    <div c={c()*2} e={{e:'e'}} {...c()*2} a='a' d={d(function(){return d;})} b f={{e:'e',f:'f'}} g={g({g:'g'})} h={{h:function(){return h;}}}>text</div>
 </div>

--- a/test/compare-jsx/element-statement.expected.jsx
+++ b/test/compare-jsx/element-statement.expected.jsx
@@ -9,8 +9,9 @@ function a() {
 }
 function a() {
     return (
-        <div a='a' b='b' d='d'
-            c={c}/>
+        <div a='a' b='b'
+            c={c}
+            d='d'/>
     );
 }
 function a() {

--- a/test/compare-jsx/real-world.expected.jsx
+++ b/test/compare-jsx/real-world.expected.jsx
@@ -1,9 +1,10 @@
 function a() {
     var _this = this;
     return (
-        <div a='a' e
+        <div a='a'
             b={b}
             c={c + d}
+            e
             f={_this.onclick(function (e) {
                 var x = 'x';
                 return <this.props.component/>;

--- a/test/source-map.js
+++ b/test/source-map.js
@@ -54,11 +54,11 @@ describe('source map test', function () {
             "defaults": [],
             "body": {
                 "type": "BlockStatement",
-                "body": [],
+                "body": []
             },
             "rest": null,
             "generator": false,
-            "expression": false,
+            "expression": false
         };
 
         // function x() {\n}
@@ -68,7 +68,7 @@ describe('source map test', function () {
         });
 
         // contains mapping for identifier
-        expect(result.map._mappings.some(function (mapping) {
+        expect(result.map._mappings.toArray().some(function (mapping) {
             return mapping.generatedLine == 1 &&
                 mapping.generatedColumn == 9 &&
                 mapping.originalLine == 2 &&
@@ -142,9 +142,9 @@ describe('source map test', function () {
         }
 
         // found x param mapping
-        expect(result.map._mappings.filter(isXParam).length).to.be.equal(1);
+        expect(result.map._mappings.toArray().filter(isXParam).length).to.be.equal(1);
         // found y param mapping
-        expect(result.map._mappings.filter(isYParam).length).to.be.equal(1);
+        expect(result.map._mappings.toArray().filter(isYParam).length).to.be.equal(1);
     });
 
     it('MemberExpression test', function () {
@@ -212,10 +212,10 @@ describe('source map test', function () {
         }
 
         // found object mapping
-        expect(result.map._mappings.filter(isObject).length).to.be.equal(1);
+        expect(result.map._mappings.toArray().filter(isObject).length).to.be.equal(1);
 
         // found one property mapping
-        expect(result.map._mappings.filter(isProperty).length).to.be.equal(1);
+        expect(result.map._mappings.toArray().filter(isProperty).length).to.be.equal(1);
     });
 
     it('Declaration in Function test', function () {
@@ -297,7 +297,7 @@ describe('source map test', function () {
         });
 
         // "found a declaration node"
-        expect(result.map._mappings.filter(function (x) {
+        expect(result.map._mappings.toArray().filter(function (x) {
             return x.originalLine == 1 && x.originalColumn == 6;
         }).length).to.be.equal(1);
     });


### PR DESCRIPTION
added support of [spread attribute](http://facebook.github.io/react/docs/jsx-spread.html), but for it I have to remove yours attributes sorting because final js code with spread attribute looks like this
```javascript
<Item a="1" {...test} b="2"/>
React.createElement(Item, React.__spread({a: "1"},  test, {b: "2"}))
```
so if `test` object has `b` field, then it will be overwritten with `{b: "2"}`. If attributes will be sorted, then `b` will be before `test` and `b` will be overwritten with `test.b` field

Also
I fixed lint bugs. There no reasons to put fields names like `attributes` and `static` in brackets, they works fine with dot notation even in IE

Also
Fixed source maps tests